### PR TITLE
SEO improvements: social preview images, canonical domain, robots, sitemap & per-page metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,6 +13,7 @@ export const viewport = {
 };
 
 export const metadata = {
+  metadataBase: new URL('https://chefinhoia.com.br'),
   title: 'Chefinho IA - Criador de receitas com IA',
   keywords:
     'receitas, inteligência artificial, IA, comida, culinária, receitas personalizadas, comidas saudáveis, receita para almoço, receita para jantar, receitas fáceis, receitas rápidas',
@@ -20,15 +21,13 @@ export const metadata = {
   openGraph: {
     title: 'Chefinho IA',
     description: 'Receitas inteligentes com IA para o seu dia a dia.',
-    url: 'https://www.chefinhoia.com.br/',
+    url: 'https://chefinhoia.com.br/',
     type: 'website',
-    images: ['https://www.chefinhoia.com.br/og-image.png'],
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Chefinho IA',
     description: 'Descubra receitas personalizadas com inteligência artificial.',
-    images: ['https://www.chefinhoia.com.br/og-image.png'],
   },
   icons: {
     icon: '/favicon.ico',

--- a/app/login/layout.tsx
+++ b/app/login/layout.tsx
@@ -1,0 +1,9 @@
+export const metadata = {
+  title: 'Entrar | Chefinho IA',
+  description: 'Acesse sua conta do Chefinho IA para criar e salvar receitas personalizadas com inteligência artificial.',
+  alternates: { canonical: '/login' },
+};
+
+export default function LoginLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,45 @@
+import { ImageResponse } from 'next/og';
+
+// Route segment config
+export const alt = 'Chefinho IA - Criador de receitas com IA';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+// Brand colors (see tailwind.config.js)
+const CREAM = '#f6e8d3';
+const TEAL = '#0f6374';
+const ORANGE = '#f6af4c';
+
+export default function OpengraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: CREAM,
+          fontFamily: 'sans-serif',
+          padding: '80px',
+          textAlign: 'center',
+        }}
+      >
+        <div style={{ fontSize: 120, marginBottom: 24 }}>🍳</div>
+        <div style={{ fontSize: 96, fontWeight: 700, color: TEAL, lineHeight: 1.1 }}>
+          Chefinho IA
+        </div>
+        <div style={{ fontSize: 40, color: ORANGE, fontWeight: 600, marginTop: 12 }}>
+          Criador de receitas com IA
+        </div>
+        <div style={{ fontSize: 32, color: TEAL, marginTop: 32, maxWidth: 900 }}>
+          Crie receitas com os ingredientes que você já tem em casa, usando o poder da
+          Inteligência Artificial!
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/app/plans/layout.tsx
+++ b/app/plans/layout.tsx
@@ -1,0 +1,9 @@
+export const metadata = {
+  title: 'Planos e Preços | Chefinho IA',
+  description: 'Conheça os planos do Chefinho IA e desbloqueie receitas ilimitadas criadas com inteligência artificial.',
+  alternates: { canonical: '/plans' },
+};
+
+export default function PlansLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/privacy/layout.tsx
+++ b/app/privacy/layout.tsx
@@ -1,0 +1,9 @@
+export const metadata = {
+  title: 'Política de Privacidade | Chefinho IA',
+  description: 'Saiba como o Chefinho IA coleta, usa e protege seus dados pessoais ao criar receitas com inteligência artificial.',
+  alternates: { canonical: '/privacy' },
+};
+
+export default function PrivacyLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/recipe/layout.tsx
+++ b/app/recipe/layout.tsx
@@ -1,0 +1,9 @@
+export const metadata = {
+  title: 'Criar receita com IA | Chefinho IA',
+  description: 'Informe os ingredientes que você já tem em casa e deixe a inteligência artificial criar uma receita personalizada para você.',
+  alternates: { canonical: '/recipe' },
+};
+
+export default function RecipeLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -5,6 +5,13 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: '*',
       allow: '/',
+      // Private / app routes that should not be indexed
+      disallow: [
+        '/profile',
+        '/minhas-receitas',
+        '/password-reset',
+        '/plans/thank-you',
+      ],
     },
     sitemap: 'https://chefinhoia.com.br/sitemap.xml',
   }

--- a/app/signup/layout.tsx
+++ b/app/signup/layout.tsx
@@ -1,0 +1,9 @@
+export const metadata = {
+  title: 'Criar conta | Chefinho IA',
+  description: 'Crie sua conta gratuita no Chefinho IA e comece a gerar receitas personalizadas com os ingredientes que você já tem em casa.',
+  alternates: { canonical: '/signup' },
+};
+
+export default function SignupLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,12 +1,25 @@
 import type { MetadataRoute } from 'next'
 
+const BASE_URL = 'https://chefinhoia.com.br'
+
 export default function sitemap(): MetadataRoute.Sitemap {
-  return [
-    {
-      url: 'https://chefinhoia.com.br/',
-      lastModified: new Date().toISOString(),
-      changeFrequency: 'weekly',
-      priority: 1.0,
-    },
+  const lastModified = new Date().toISOString()
+
+  // Public, indexable static routes
+  const routes: { path: string; changeFrequency: MetadataRoute.Sitemap[number]['changeFrequency']; priority: number }[] = [
+    { path: '/', changeFrequency: 'weekly', priority: 1.0 },
+    { path: '/recipe', changeFrequency: 'weekly', priority: 0.9 },
+    { path: '/plans', changeFrequency: 'monthly', priority: 0.8 },
+    { path: '/signup', changeFrequency: 'monthly', priority: 0.6 },
+    { path: '/login', changeFrequency: 'monthly', priority: 0.5 },
+    { path: '/terms', changeFrequency: 'yearly', priority: 0.3 },
+    { path: '/privacy', changeFrequency: 'yearly', priority: 0.3 },
   ]
+
+  return routes.map(({ path, changeFrequency, priority }) => ({
+    url: `${BASE_URL}${path}`,
+    lastModified,
+    changeFrequency,
+    priority,
+  }))
 }

--- a/app/terms/layout.tsx
+++ b/app/terms/layout.tsx
@@ -1,0 +1,9 @@
+export const metadata = {
+  title: 'Termos de Serviço | Chefinho IA',
+  description: 'Termos de Serviço do Chefinho IA: regras de uso da plataforma de criação de receitas com inteligência artificial.',
+  alternates: { canonical: '/terms' },
+};
+
+export default function TermsLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/twitter-image.tsx
+++ b/app/twitter-image.tsx
@@ -1,0 +1,2 @@
+// Reuse the Open Graph image for Twitter/X cards.
+export { default, alt, size, contentType } from './opengraph-image';


### PR DESCRIPTION
## Summary

A first batch of SEO quick-wins for Chefinho IA. All changes are verified against a real `next build` (20/20 routes compile; generated `robots.txt`/`sitemap.xml` inspected).

### Social previews (commit `5d94162`)
- **Fixed broken OG image.** Metadata pointed at `https://www.chefinhoia.com.br/og-image.png`, which 404s (no such file). Replaced with branded images generated via `next/og`:
  - `app/opengraph-image.tsx` — 1200×630 card in brand palette (cream/teal/orange).
  - `app/twitter-image.tsx` — reuses the same generator for X/Twitter cards.
- **Canonical domain.** Standardized on non-`www` `chefinhoia.com.br` to match `robots.ts` / `sitemap.ts` (was `www` in layout — split signals).
- **`metadataBase`** added so relative OG/canonical URLs resolve correctly (also clears a build warning).

### Crawl & indexing (commit `121062d`)
- **`robots.txt`** now disallows private/app routes: `/profile`, `/minhas-receitas`, `/password-reset`, `/plans/thank-you`.
- **`sitemap.xml`** expanded from just the homepage to all 7 public static routes with priorities.
- **Per-page metadata** (unique title/description/canonical):
  - `terms`, `privacy` — added directly (server components).
  - `recipe`, `plans`, `login`, `signup` — added via new server `layout.tsx` files (these pages are `'use client'` and can't export `metadata` themselves).

## Notes / follow-ups (not in this PR)
- `/recipe/[id]` currently inherits the generic "Criar receita com IA" title from the `recipe` layout. Proper per-recipe titles + `Recipe` JSON-LD structured data is a larger follow-up that depends on whether recipe detail pages should be publicly indexable.
- Two remaining micro-fixes pending: `alt="test"` on the landing hero image, and dropping the dead `keywords` meta tag.

## Decision needed
If you serve `www.chefinhoia.com.br` as your canonical host instead of the bare domain, flip the URLs in `app/layout.tsx`, `app/robots.ts`, and `app/sitemap.ts`.

https://claude.ai/code/session_01BoD29Zr9kANBkfo3nV9kge

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoD29Zr9kANBkfo3nV9kge)_