### PR TITLE
Fix home route redirect + SEO micro-fixes (follow-up to #24)

### DIFF
--- a/app/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/app/components/ProtectedRoute/ProtectedRoute.tsx
@@ -10,7 +10,7 @@ const ProtectedRoute = ({ children }: { children: React.ReactNode; }) => {
   const { getUser } = useUserAuth();
   const { setUser } = useUserStore();
   
-  const alwaysPublicPaths = ['/terms', '/privacy', '/plans-public'];
+  const alwaysPublicPaths = ['/', '/terms', '/privacy', '/plans-public'];
   const alwaysPublicPrefixes = ['/recipe/'];
   const authPublicPaths = ['/login', '/signup', '/password-reset'];
   

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,8 +15,6 @@ export const viewport = {
 export const metadata = {
   metadataBase: new URL('https://chefinhoia.com.br'),
   title: 'Chefinho IA - Criador de receitas com IA',
-  keywords:
-    'receitas, inteligência artificial, IA, comida, culinária, receitas personalizadas, comidas saudáveis, receita para almoço, receita para jantar, receitas fáceis, receitas rápidas',
   description: 'Crie receitas com os ingredientes que você já tem em casa, usando o poder da Inteligência Artificial!',
   openGraph: {
     title: 'Chefinho IA',

--- a/app/pages/Landing.tsx
+++ b/app/pages/Landing.tsx
@@ -27,7 +27,7 @@ export default function Landing() {
           src="/images/people-cooking.svg"
           width={250}
           height={200}
-          alt="test"
+          alt="Pessoas cozinhando receitas criadas com inteligência artificial"
           className="mt-20 z-10 w-auto"
         />
         <h1 className="font-semibold mt-16 z-10">Chefinho IA</h1>


### PR DESCRIPTION
## Summary

Follow-up to #24 (already merged). These two commits landed on the branch **after** #24 was merged, so they're not yet in `main`.

### Bug fix — home route redirect (`dd1adbb`)
`ProtectedRoute` treated `/` as a protected path and pushed unauthenticated visitors to `/login`, hiding the Landing page (and bouncing crawlers). `app/page.tsx` already renders Landing for logged-out users and HomeDashboard for logged-in ones, so `/` is now marked always-public.

- Logged-out → `/` shows Landing ✅
- Logged-in → `/` shows HomeDashboard ✅

### SEO micro-fixes (`0ccf6dd`)
- Replace placeholder `alt="test"` on the landing hero image with descriptive alt text (accessibility + image search).
- Remove the `keywords` meta tag (Google has ignored it since 2009).

Build verified — `next build` passes, 23/23 routes.

https://claude.ai/code/session_01BoD29Zr9kANBkfo3nV9kge

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoD29Zr9kANBkfo3nV9kge)_