### PR TITLE
SEO: Recipe structured data + Organization/WebSite JSON-LD

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -39,10 +39,36 @@ export const metadata = {
   },
 };
 
+const organizationJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: 'Chefinho IA',
+  url: 'https://chefinhoia.com.br',
+  logo: 'https://chefinhoia.com.br/icons/icon-512x512.png',
+  description:
+    'Crie receitas com os ingredientes que você já tem em casa, usando o poder da Inteligência Artificial.',
+};
+
+const websiteJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: 'Chefinho IA',
+  url: 'https://chefinhoia.com.br',
+  inLanguage: 'pt-BR',
+};
+
 export default function RootLayout({ children }) {
   return (
     <html lang="pt-BR">
       <body className={`${rubik.className} flex flex-col min-h-screen`}>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }}
+        />
         <GoogleOAuthProvider clientId={process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID}>
           <ClientWrapper>{children}</ClientWrapper>
           <Footer />

--- a/app/recipe/[id]/getRecipe.ts
+++ b/app/recipe/[id]/getRecipe.ts
@@ -1,0 +1,43 @@
+import { initializeApp, getApps, getApp } from 'firebase/app';
+import { getFirestore, doc, getDoc } from 'firebase/firestore';
+import { cache } from 'react';
+
+// Public web config (same project as app/hooks/userAuth.ts). Re-declared here
+// so server components can read Firestore without importing the client auth
+// module, which calls setPersistence() with browser-only APIs at import time.
+const firebaseConfig = {
+  apiKey: 'AIzaSyAUTRpjufvz16h_B-1a9S-zk5r-3-b6wBY',
+  authDomain: 'recipe-app-1bbdc.firebaseapp.com',
+  projectId: 'recipe-app-1bbdc',
+};
+
+const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
+const db = getFirestore(app);
+
+export interface RecipeDoc {
+  title: string;
+  introduction?: string;
+  ingredients?: string[];
+  preparationMethod?: string[];
+  observations?: string[];
+  nutritionalInfo?: {
+    calorias?: string;
+    proteinas?: string;
+    carboidratos?: string;
+    gorduras?: string;
+    fibras?: string;
+  };
+  imageUrl?: string;
+  createdAt?: { seconds: number } | null;
+}
+
+// Cached per-request so generateMetadata and the layout share one read.
+export const getRecipe = cache(async (id: string): Promise<RecipeDoc | null> => {
+  try {
+    const snap = await getDoc(doc(db, 'recipes', id));
+    return snap.exists() ? (snap.data() as RecipeDoc) : null;
+  } catch {
+    // Network/permission failure: degrade gracefully to generic metadata.
+    return null;
+  }
+});

--- a/app/recipe/[id]/layout.tsx
+++ b/app/recipe/[id]/layout.tsx
@@ -1,0 +1,102 @@
+import type { Metadata } from 'next';
+import { getRecipe } from './getRecipe';
+
+type Params = { params: { id: string } };
+
+function buildDescription(recipe: { title: string; introduction?: string }): string {
+  const text =
+    recipe.introduction?.trim() ||
+    `Receita de ${recipe.title} criada com inteligência artificial pelo Chefinho IA.`;
+  return text.length > 160 ? `${text.slice(0, 157)}…` : text;
+}
+
+export async function generateMetadata({ params }: Params): Promise<Metadata> {
+  const canonical = `/recipe/${params.id}`;
+  const recipe = await getRecipe(params.id);
+
+  if (!recipe) {
+    return {
+      title: 'Receita | Chefinho IA',
+      alternates: { canonical },
+    };
+  }
+
+  const description = buildDescription(recipe);
+
+  return {
+    title: `${recipe.title} | Chefinho IA`,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      title: recipe.title,
+      description,
+      type: 'article',
+      url: canonical,
+      ...(recipe.imageUrl ? { images: [recipe.imageUrl] } : {}),
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: recipe.title,
+      description,
+      ...(recipe.imageUrl ? { images: [recipe.imageUrl] } : {}),
+    },
+  };
+}
+
+export default async function RecipeIdLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: { id: string };
+}) {
+  const recipe = await getRecipe(params.id);
+
+  const jsonLd = recipe
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'Recipe',
+        name: recipe.title,
+        ...(recipe.introduction ? { description: recipe.introduction } : {}),
+        ...(recipe.imageUrl ? { image: recipe.imageUrl } : {}),
+        author: { '@type': 'Organization', name: 'Chefinho IA' },
+        ...(recipe.createdAt?.seconds
+          ? { datePublished: new Date(recipe.createdAt.seconds * 1000).toISOString() }
+          : {}),
+        ...(recipe.ingredients?.length ? { recipeIngredient: recipe.ingredients } : {}),
+        ...(recipe.preparationMethod?.length
+          ? {
+              recipeInstructions: recipe.preparationMethod.map((step, i) => ({
+                '@type': 'HowToStep',
+                position: i + 1,
+                text: step,
+              })),
+            }
+          : {}),
+        ...(recipe.nutritionalInfo
+          ? {
+              nutrition: {
+                '@type': 'NutritionInformation',
+                ...(recipe.nutritionalInfo.calorias ? { calories: recipe.nutritionalInfo.calorias } : {}),
+                ...(recipe.nutritionalInfo.proteinas ? { proteinContent: recipe.nutritionalInfo.proteinas } : {}),
+                ...(recipe.nutritionalInfo.carboidratos ? { carbohydrateContent: recipe.nutritionalInfo.carboidratos } : {}),
+                ...(recipe.nutritionalInfo.gorduras ? { fatContent: recipe.nutritionalInfo.gorduras } : {}),
+                ...(recipe.nutritionalInfo.fibras ? { fiberContent: recipe.nutritionalInfo.fibras } : {}),
+              },
+            }
+          : {}),
+      }
+    : null;
+
+  return (
+    <>
+      {jsonLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      )}
+      {children}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

The bigger organic-search items from the SEO audit: per-recipe metadata + structured data, and sitewide Organization/WebSite JSON-LD.

### Recipe pages — `generateMetadata` + `Recipe` JSON-LD
`app/recipe/[id]/page.tsx` is a large `'use client'` component, so instead of converting it, this adds a **server `layout.tsx`** that owns SEO for the route:
- **`generateMetadata`** — per-recipe `title`, `description`, `canonical`, and OpenGraph/Twitter (uses the recipe image when present). This also replaces the generic "Criar receita com IA" title these pages previously inherited.
- **schema.org/Recipe JSON-LD** — name, description, image, ingredients (`recipeIngredient`), steps (`HowToStep`), and nutrition (`NutritionInformation`) → eligible for Google's rich recipe results.
- **`getRecipe.ts`** — reads Firestore server-side via a server-safe init (does **not** import `userAuth.ts`, which calls `setPersistence()` with browser APIs at import). Wrapped in `cache()` so `generateMetadata` and the layout share one read. Fails closed: on network/permission error it returns `null` and the page degrades to generic metadata with no JSON-LD.

### Homepage — Organization + WebSite JSON-LD
Added to the root layout (server-rendered): `Organization` (name, url, logo, description) and `WebSite` (name, url, language) to help Google build the brand entity.

## Verified
- `next build` passes — 23/23 routes; `/recipe/[id]` remains dynamic (ƒ), rendered per request so `generateMetadata` runs server-side.

## Notes
- Recipe pages are intended to be publicly indexable (confirmed). A future community-recipes listing page would be a good surface to link these from and add to the sitemap.

https://claude.ai/code/session_01BoD29Zr9kANBkfo3nV9kge

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoD29Zr9kANBkfo3nV9kge)_